### PR TITLE
allow couchdb ssl endpoints

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source "https://rubygems.org"
 
 gem 'rake'
 gem 'json'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   specs:
     diff-lcs (1.2.1)
     json (1.7.7)
@@ -33,3 +33,6 @@ DEPENDENCIES
   reek
   rspec
   transport (>= 1.0.2)
+
+BUNDLED WITH
+   1.11.2

--- a/lib/couchdb/server.rb
+++ b/lib/couchdb/server.rb
@@ -48,7 +48,8 @@ class CouchDB::Server
   end
 
   def url
-    "http://#{self.host}:#{self.port}"
+    protocol = self.port == 6984 ? "https" : "http"
+    "#{protocol}://#{self.host}:#{self.port}"
   end
 
   def authentication_options


### PR DESCRIPTION
use https instead of http when the port is 6984 (default couch ssl port)
